### PR TITLE
Adding MacOS build support and automatic OS detection (Linux VS MacOS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,25 @@
+UNAME_S := $(shell uname -s)
+
 all:
+ifeq ($(UNAME_S),Linux)
+	@echo "Linux detected..."
+	@$(MAKE) linux
+else ifeq ($(UNAME_S),Darwin)
+	@echo "MacOS detected..."
+	@$(MAKE) macos
+endif
+
+linux:
 	gcc main.c util.c -o fnirsi-dfu-update -lhidapi-hidraw
+
+macos: brew-install-hidapi
+	gcc main.c util.c -o fnirsi-dfu-update -I/opt/homebrew/include -L/opt/homebrew/lib -lhidapi
+
+brew-install-hidapi:
+	@echo "Looking for hidapi..."
+	@brew list -q hidapi 1>/dev/null || brew install hidapi
+
+clean:
+	rm fnirsi-dfu-update
 
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 Quick & dirty tool to update FNB58's firmware on Linux. Original tool works under wine, but that's a simpler alternative if you just want to update and get it over.
 
-You might need to add the following udev rule to make sure you have access to the device:
-```
-KERNEL=="hidraw*", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="0038", GROUP="uucp", MODE="0660"
-```
-Alternatively, you can run the tool as root.
+## How to build
+
+Building on Linux or MacOS should be the same using the `make` command. The makefile automatically detects the OS and runs the right build command. If OS detection fails you can build manually with `make linux` or `make macos`.
+
+Note: Only tested it on MacOS 15. Other versions are not guaranteed.
+
+### MacOS hidapi dependency
+
+As the `hidapi` library is a dependency it needs to be installed using `make brew-install-hidapi` or `brew install hidapi`.
 
 ## How to use?
 
 Plug your device to your computer's USB port while pressing 'select' button (navigation wheel). You should see splash screen indicating that you're in DFU mode.
+
+On Linux you might need to add the following udev rule to make sure you have access to the device:
+```
+KERNEL=="hidraw*", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="0038", GROUP="uucp", MODE="0660"
+```
+Alternatively, you can run the tool as root.
 
 Then, simply run the tool:
 ```
@@ -26,3 +36,4 @@ all done!
 ```
 
 *WARNING* - this is tested only a couple times - expect issues!
+

--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ all done!
 
 *WARNING* - this is tested only a couple times - expect issues!
 
+## FNB58 Firmwares
+
+Can be downloaded from:
+1. https://www.fnirsi.com/pages/manuals-firmwares?category=signal-analysis
+2. or https://github.com/Rhomboid/fnb58-archive
+

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@ Quick & dirty tool to update FNB58's firmware on Linux. Original tool works unde
 
 ## How to build
 
-Building on Linux or MacOS should be the same using the `make` command. The makefile automatically detects the OS and runs the right build command. If OS detection fails you can build manually with `make linux` or `make macos`.
+Building on Linux or MacOS are the same by running the `make` command.
+The makefile automatically detects the OS and runs the right build command and installs `hidapi` from brew if missing.
 
 Note: Only tested it on MacOS 15. Other versions are not guaranteed.
 
 ### MacOS hidapi dependency
 
-As the `hidapi` library is a dependency it needs to be installed using `make brew-install-hidapi` or `brew install hidapi`.
+As the `hidapi` library is a dependency it needs to be installed. The make script should automatically install it from `brew` on MacOS. On Linux you have to install it manually.
 
 ## How to use?
 


### PR DESCRIPTION
Adding MacOS build support and automatic OS detection (Linux VS MacOS).

On MacOS It also installs the `hidapi` dependency from `brew` in case it is missing.

Also updated the README.md