### PR TITLE
Derive the firmware version code from the file name, and fix HID read error handling

### DIFF
--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <hidapi/hidapi.h>
 #include <unistd.h>
 #include <stdbool.h>
@@ -94,10 +95,9 @@ static bool fw_upload_write_data(hid_device *hid, size_t i, void *data, size_t l
     return ok && listen_for_response(hid, write_timeout_ms);
 }
 
-static bool fw_update_with_handle(hid_device *handle, void *fw, size_t fw_size)
+static bool fw_update_with_handle(hid_device *handle, void *fw, size_t fw_size,
+                                  uint16_t fw_version)
 {
-    // XXX:I'm not sure whether that has any effect. This is extracted from FW file name.
-    const uint8_t fw_version = 68;
     bool ok;
 
     printf("clearing flash...\n");
@@ -137,7 +137,7 @@ static bool fw_update_with_handle(hid_device *handle, void *fw, size_t fw_size)
     return ok;
 }
 
-static bool open_dev_and_update(void *fw, size_t fw_size)
+static bool open_dev_and_update(void *fw, size_t fw_size, uint16_t fw_version)
 {
     const uint16_t vid = 0x0483;
     const uint16_t pid = 0x0038;
@@ -148,20 +148,131 @@ static bool open_dev_and_update(void *fw, size_t fw_size)
         return false;
     }
 
-    bool ok = fw_update_with_handle(handle, fw, fw_size);
+    bool ok = fw_update_with_handle(handle, fw, fw_size, fw_version);
 
     hid_close(handle);
     return ok;
 }
 
+/* Derive the version code the device expects from the firmware file name.
+ *
+ * The .ufn payload is fully encrypted (no header, no magic, size always a
+ * multiple of the cipher block), so the file name is the only place the
+ * version appears in plain form. FNIRSI's own naming maps to the code by
+ * simply dropping the dots:
+ *
+ *   Fnb58V0.68.ufn  -> 68    (the value the original tool hardcoded)
+ *   Fnb58V1.0.3.ufn -> 103   (three-component versions do exist)
+ *   Fnb58V1.15.ufn  -> 115
+ *
+ * A candidate is a 'v'/'V' followed by a digit, then a run of digits and
+ * dots. Real versions always contain a dot, so a dotted candidate wins over
+ * a bare one ("v2_final" style words in a name do not hijack the result).
+ */
+static bool parse_version_at(const char *p, uint16_t *out, bool *had_dot)
+{
+    unsigned long code = 0;
+    bool any_digit = false;
+
+    *had_dot = false;
+
+    for (const char *q = p; isdigit((unsigned char)*q) || *q == '.'; q++) {
+        if (*q == '.') {
+            *had_dot = true;
+            continue;
+        }
+
+        code = code * 10 + (unsigned long)(*q - '0');
+        any_digit = true;
+
+        if (code > UINT16_MAX) {
+            return false;
+        }
+    }
+
+    if (!any_digit) {
+        return false;
+    }
+
+    *out = (uint16_t)code;
+    return true;
+}
+
+static bool version_from_filename(const char *path, uint16_t *out)
+{
+    const char *base = strrchr(path, '/');
+    base = base? base + 1 : path;
+
+    bool found = false;
+    uint16_t fallback = 0;
+
+    for (const char *p = base; *p; p++) {
+        if ((*p != 'v' && *p != 'V') || !isdigit((unsigned char)p[1])) {
+            continue;
+        }
+
+        uint16_t code;
+        bool had_dot;
+
+        if (!parse_version_at(p + 1, &code, &had_dot)) {
+            continue;
+        }
+
+        if (had_dot) {
+            *out = code;
+            return true;
+        }
+
+        if (!found) {
+            fallback = code;
+            found = true;
+        }
+    }
+
+    if (found) {
+        *out = fallback;
+    }
+
+    return found;
+}
 int main(int argc, char **argv)
 {
-    if (argc != 2) {
-        printf("usage: %s: <filename.ufn>\n", argv[0]);
+    const char *filename = NULL;
+    bool have_override = false;
+    uint16_t fw_version = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--version") == 0) {
+            if (i + 1 >= argc) {
+                printf("--version needs a value\n");
+                return 1;
+            }
+
+            char *end;
+            unsigned long v = strtoul(argv[++i], &end, 10);
+
+            if (*end || v > UINT16_MAX) {
+                printf("invalid version code '%s'\n", argv[i]);
+                return 1;
+            }
+
+            fw_version = (uint16_t)v;
+            have_override = true;
+        } else if (!filename) {
+            filename = argv[i];
+        } else {
+            filename = NULL;
+            break;
+        }
+    }
+
+    if (!filename) {
+        printf("usage: %s [--version <code>] <filename.ufn>\n", argv[0]);
+        printf("  the version code is normally derived from the file name\n");
+        printf("  (Fnb58V1.15.ufn -> 115); --version overrides that.\n");
         return 1;
     }
 
-    const char *filename = argv[1];
     void *fw;
     size_t fw_size = 0;
 
@@ -173,7 +284,18 @@ int main(int argc, char **argv)
 
     printf("'%s' read, %zu bytes\n", filename, fw_size);
 
-    ok = open_dev_and_update(fw, fw_size);
+    if (have_override) {
+        printf("declaring firmware version code %u (from --version)\n", fw_version);
+    } else if (version_from_filename(filename, &fw_version)) {
+        printf("declaring firmware version code %u (from file name)\n", fw_version);
+    } else {
+        printf("unable to derive a version code from file name '%s'\n", filename);
+        printf("pass --version <code> explicitly (e.g. 115 for V1.15)\n");
+        free(fw);
+        return 1;
+    }
+
+    ok = open_dev_and_update(fw, fw_size, fw_version);
     free(fw);
 
     if (ok) {

--- a/main.c
+++ b/main.c
@@ -39,9 +39,9 @@ static bool listen_for_response(hid_device *hid, int timeout_ms)
 
     memset(buffer, 0, MAX_PACKET_PAYLOAD_SIZE);
 
-    bool ok = hid_read_timeout(hid, buffer, MAX_PACKET_PAYLOAD_SIZE, timeout_ms);
-    if (!ok) {
-        printf("read error!\n");
+    int n = hid_read_timeout(hid, buffer, MAX_PACKET_PAYLOAD_SIZE, timeout_ms);
+    if (n <= 0) {
+        printf("read error (%d)!\n", n);
         return false;
     }
 


### PR DESCRIPTION
Two independent fixes, one commit each. Both found while using the tool to flash **V1.15** onto an FNB58 on Linux — which worked, thanks for writing this.

## 1. The version code was hardcoded to 68

```c
// XXX:I'm not sure whether that has any effect. This is extracted from FW file name.
const uint8_t fw_version = 68;
```

`68` is V0.68, so flashing any other release declared a version that doesn't match the image being written. This does what the `XXX` says and takes it from the file name.

FNIRSI's naming maps to the code by dropping the dots, which reproduces the hardcoded value for the release the tool was originally tested with:

| file name | code |
|---|---|
| `Fnb58V0.68.ufn` | 68 (unchanged from the hardcoded value) |
| `Fnb58V1.0.3.ufn` | 103 |
| `Fnb58V1.15.ufn` | 115 |

Three-component versions like `V1.0.3` do exist — it's in FNIRSI's own changelog — so `major * 100 + minor` is not enough; dropping dots handles it.

Deriving from the name rather than reading the version out of the image is forced, not preference. The `.ufn` payload is encrypted end to end: no header or magic, entropy 7.9995/8, sizes always a multiple of 16, no 16-byte block repeating within or across releases (so not ECB), and the XOR of two releases is indistinguishable from random (so no reused keystream). The file name is the only place the version is legible.

Details:

- A candidate is `v`/`V` followed by a digit. Real versions always contain a dot, so a dotted candidate wins — a `v2`-style word elsewhere in the name can't hijack the result.
- The parameter widens to `uint16_t`, which `fw_start_update()` already expected; the old `uint8_t` would have truncated anything past 255.
- If no version can be found the tool now stops instead of flashing under a guessed value, and `--version <code>` overrides the file name.

Verified against every release in the V1.15 changelog (V0.20 through V1.15), plus lowercase names and a decoy `v2` in the file name.

I should flag the limit of that evidence: `V0.68 -> 68` is the only value confirmed against a device by someone other than me, and `V1.15 -> 115` is confirmed by my own successful flash. The rest follow the same rule but are untested. Your `XXX` may well be right that the field is ignored entirely — this at least makes it consistent rather than wrong.

## 2. A HID read error counted as success

```c
bool ok = hid_read_timeout(hid, buffer, MAX_PACKET_PAYLOAD_SIZE, timeout_ms);
```

`hid_read_timeout()` returns bytes read, `0` on timeout, `-1` on error. Assigned to a `bool`, `-1` is truthy — so a genuine HID error passed the `!ok` check and counted as a valid ack.

That lands in the worst possible place: the write loop calls this after every 58-byte chunk, so a device erroring mid-flash would keep being fed the rest of the image and the tool would still print `all done!`. Now checks `n <= 0`, and prints the return value so a timeout (`0`) is distinguishable from an error (`-1`).

## Testing

Builds clean on Linux with gcc, no new warnings. The version derivation was tested through the built binary rather than a copy of the logic. Flashed V1.15 to a real FNB58 with these changes; the device runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zMQeHsorgSw7N682UiUKn
